### PR TITLE
convert.py : never alter the global default config

### DIFF
--- a/csv_ical/convert.py
+++ b/csv_ical/convert.py
@@ -29,7 +29,7 @@ class Convert():
     def _generate_configs_from_default(self, overrides=None):
         # type: (Dict[str, int]) -> Dict[str, int]
         """ Generate configs by inheriting from defaults """
-        config = DEFAULT_CONFIG
+        config = DEFAULT_CONFIG.copy()
         if not overrides:
             overrides = {}
         for k, v in overrides.items():


### PR DESCRIPTION
The overrides given to _generate_configs_from_default will only alter the config of the instance.