### PR TITLE
UTF8 encoding and blank lines fix

### DIFF
--- a/csv_ical/convert.py
+++ b/csv_ical/convert.py
@@ -38,7 +38,7 @@ class Convert():
 
     def read_ical(self, ical_file_location):  # type: (str) -> Calendar
         """ Read the ical file """
-        with open(ical_file_location, 'r') as ical_file:
+        with open(ical_file_location, 'r', encoding="utf8") as ical_file:
             data = ical_file.read()
         self.cal = Calendar.from_ical(data)
         return self.cal
@@ -47,7 +47,7 @@ class Convert():
         # type: (str, Dict[str, int]) -> List[List[str]]
         """ Read the csv file """
         csv_configs = self._generate_configs_from_default(csv_configs)
-        with open(csv_location, 'r') as csv_file:
+        with open(csv_location, 'r', encoding="utf8") as csv_file:
             csv_reader = csv.reader(csv_file)
             self.csv_data = list(csv_reader)
         self.csv_data = self.csv_data[csv_configs['HEADER_COLUMNS_TO_SKIP']:]
@@ -86,12 +86,12 @@ class Convert():
     def save_ical(self, ical_location):  # type: (str) -> None
         """ Save the calendar instance to a file """
         data = self.cal.to_ical()
-        with open(ical_location, 'w') as ical_file:
+        with open(ical_location, 'w', encoding="utf8", newline='') as ical_file:
             ical_file.write(data.decode('utf-8'))
 
     def save_csv(self, csv_location):  # type: (str) -> None
         """ Save the csv to a file """
-        with open(csv_location, 'w') as csv_handle:
+        with open(csv_location, 'w', encoding="utf8", newline='') as csv_handle:
             writer = csv.writer(csv_handle)
             for row in self.csv_data:
                 writer.writerow(row)

--- a/csv_ical/convert.py
+++ b/csv_ical/convert.py
@@ -38,7 +38,7 @@ class Convert():
 
     def read_ical(self, ical_file_location):  # type: (str) -> Calendar
         """ Read the ical file """
-        with open(ical_file_location, 'r', encoding="utf8") as ical_file:
+        with open(ical_file_location, 'r', encoding="utf-8") as ical_file:
             data = ical_file.read()
         self.cal = Calendar.from_ical(data)
         return self.cal
@@ -47,7 +47,7 @@ class Convert():
         # type: (str, Dict[str, int]) -> List[List[str]]
         """ Read the csv file """
         csv_configs = self._generate_configs_from_default(csv_configs)
-        with open(csv_location, 'r', encoding="utf8") as csv_file:
+        with open(csv_location, 'r', encoding="utf-8") as csv_file:
             csv_reader = csv.reader(csv_file)
             self.csv_data = list(csv_reader)
         self.csv_data = self.csv_data[csv_configs['HEADER_COLUMNS_TO_SKIP']:]
@@ -86,12 +86,12 @@ class Convert():
     def save_ical(self, ical_location):  # type: (str) -> None
         """ Save the calendar instance to a file """
         data = self.cal.to_ical()
-        with open(ical_location, 'w', encoding="utf8", newline='') as ical_file:
+        with open(ical_location, 'w', encoding="utf-8", newline='') as ical_file:
             ical_file.write(data.decode('utf-8'))
 
     def save_csv(self, csv_location):  # type: (str) -> None
         """ Save the csv to a file """
-        with open(csv_location, 'w', encoding="utf8", newline='') as csv_handle:
+        with open(csv_location, 'w', encoding="utf-8", newline='') as csv_handle:
             writer = csv.writer(csv_handle)
             for row in self.csv_data:
                 writer.writerow(row)


### PR DESCRIPTION
Added UTF8 encoding to address #13 issue (`encoding="utf8"`).

While testing this fix, I realized that csv_ical was adding blank lines between each line of data on both .csv and .ics output files, so I fixed that as well (`newline=''`).